### PR TITLE
Explicitly stating build architectures in build steps

### DIFF
--- a/.github/workflows/docker-buid-publish.yml
+++ b/.github/workflows/docker-buid-publish.yml
@@ -82,6 +82,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push without cache
@@ -96,6 +97,7 @@ jobs:
           no-cache: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker
       # repository is public to avoid leaking data.  If you would like to publish


### PR DESCRIPTION
As discussed in [issue 8](https://github.com/opencost/opencost-parquet-exporter/issues/8) I've added explicit mentions of the taget platforms as documented in the actions [README](https://github.com/docker/build-push-action?tab=readme-ov-file#inputs) and the docs of `docker buildx build` ([reference](https://docs.docker.com/reference/cli/docker/buildx/build/#platform)).