### PR TITLE
fix docker warning FromAsCase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:3.11-bookworm as builder
+FROM python:3.11-bookworm AS builder
 
 RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake && apt-get -y clean && mkdir  -p /app/ && python3 -m venv /app/.venv 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 COPY requirements.txt /app/
 RUN cd app && source .venv/bin/activate && pip3 install -r requirements.txt 
 
-FROM python:3.11-bookworm as runtime-image
+FROM python:3.11-bookworm AS runtime-image
 RUN apt-get update && apt-get -y upgrade && apt-get -y clean
 RUN useradd --create-home --shell /bin/sh  --uid 8000 opencost
 COPY --from=builder /app /app 


### PR DESCRIPTION
This fix a warning from docker that states the case of the from and as should be the same.