### PR TITLE
bugfix: use the script path to detect the config files path.

### DIFF
--- a/src/opencost_parquet_exporter.py
+++ b/src/opencost_parquet_exporter.py
@@ -285,13 +285,13 @@ def main():
     print("Starting run")
     print("Load data types")
     data_types = load_config_file(
-        file_path='./src/data_types.json')  # TODO: Make path ENV var
+        file_path=f'{os.path.dirname(os.path.abspath(__file__))}/data_types.json')
     print("Load renaming coloumns")
     rename_cols = load_config_file(
-        file_path='./src/rename_cols.json')  # TODO: Make path ENV var
+        file_path=f'{os.path.dirname(os.path.abspath(__file__))}/rename_cols.json')
     print("Load allocation keys to ignore")
     ignore_alloc_keys = load_config_file(
-        file_path='./src/ignore_alloc_keys.json')  # TODO: Make path ENV var
+        file_path=f'{os.path.dirname(os.path.abspath(__file__))}/ignore_alloc_keys.json')
 
     print("Build config")
     config = get_config()


### PR DESCRIPTION
The path for the config files was hardcoded and this was creating errors.

Instead of hardcoding ./src/ , we are using the script path, so it will detect the right path when running on the docker image, where the directory is /app/ instead of ./src/ .

```
root@14d0b6c7bb03:/app# python opencost_parquet_exporter.py 
Starting run
Load data types
Traceback (most recent call last):
  File "/app/opencost_parquet_exporter.py", line 321, in <module>
    main()
  File "/app/opencost_parquet_exporter.py", line 287, in main
    data_types = load_config_file(
                 ^^^^^^^^^^^^^^^^^
  File "/app/opencost_parquet_exporter.py", line 26, in load_config_file
    with open(file_path, 'r', encoding="utf-8") as file:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: './src/data_types.json'
