### PR TITLE
Fix condition to keep the compatibility with old version in AWS

### DIFF
--- a/src/storage_factory.py
+++ b/src/storage_factory.py
@@ -25,7 +25,7 @@ def get_storage(storage_backend):
     """
     if storage_backend == 'azure':
         return AzureStorage()
-    if storage_backend == 's3':
+    if storage_backend in ['s3', 'aws']:
         return S3Storage()
 
     raise ValueError("Unsupported storage backend")


### PR DESCRIPTION
i'm using the next config in k8s to save in AWS

```sh
- name: AWS_REGION
  value: <xx-xxxx-x>
- name: OPENCOST_PARQUET_FILE_KEY_PREFIX
  value: <NAME>
- name: OPENCOST_PARQUET_S3_BUCKET
  value: <NAME>
- name: OPENCOST_PARQUET_S3_REGION
  value: <xx-xxxx-x>
- name: OPENCOST_PARQUET_SVC_HOSTNAME
  value: opencost.opencost.svc.cluster.local.
- name: OPENCOST_PARQUET_SVC_PORT
  value: '9003'
```

with the last commit i'm getting the follow error

```sh
Traceback (most recent call last):
  File "/app/opencost_parquet_exporter.py", line 321, in <module>
Starting run
Load data types
Load renaming coloumns
Load allocation keys to ignore
Build config
Retrieving data from opencost api
Opencost data retrieved successfully
Processing the data
Data processed successfully
Saving data
    main()
  File "/app/opencost_parquet_exporter.py", line 317, in main
    save_result(processed_data, config)
  File "/app/opencost_parquet_exporter.py", line 272, in save_result
    storage = get_storage(storage_backend=config['storage_backend'])
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/storage_factory.py", line 31, in get_storage
    raise ValueError("Unsupported storage backend")
ValueError: Unsupported storage backend
```

then i tried with the value, how to indicated the example https://github.com/opencost/opencost-parquet-exporter/blob/v0.2.0/examples/k8s_cron_job.yaml#L39, but don't work
```sh
- name: OPENCOST_PARQUET_STORAGE_BACKEND
  value: aws
```


The error is cause by the default value is 'aws' in the main file https://github.com/opencost/opencost-parquet-exporter/blob/main/src/opencost_parquet_exporter.py#L129-L130 but the condition is with 's3' https://github.com/opencost/opencost-parquet-exporter/blob/v0.2.0/src/storage_factory.py#L28

i'm reading about is to keep the compatibility with de old version, therefore i propuse use IN with both values
