### PR TITLE
chore: bump pandas to 2.2.3 for CVE-2024-9880

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 numpy==1.26.3
-pandas==2.1.4
-boto3==1.34.21
+pandas==2.2.3
+boto3==1.35.16
 requests==2.32.0
 python-dateutil==2.8.2
 pytz==2023.3.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy==1.26.3
-pandas==2.1.4
-boto3==1.34.21
+pandas==2.2.3
+boto3==1.35.16
 requests==2.32.0
 python-dateutil==2.8.2
 pytz==2023.3.post1


### PR DESCRIPTION
pandas - CVE-2024-9880

boto3 - `awscli 1.34.16 requires botocore==1.35.16, but you have botocore 1.34.162 which is incompatible.`