### PR TITLE
feature: support Azure Workload Identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The script supports the following environment variables:
 * OPENCOST_PARQUET_AZURE_TENANT: Your Azure Tenant ID. When omitted the exporter falls back to the `AZURE_TENANT_ID` environment variable provided by Azure AD Workload Identity.
 * OPENCOST_PARQUET_AZURE_APPLICATION_ID: Client ID of the Service Principal. When omitted the exporter falls back to the `AZURE_CLIENT_ID` environment variable provided by Azure AD Workload Identity.
 * OPENCOST_PARQUET_AZURE_APPLICATION_SECRET: Secret of the Service Principal. Required when using client-secret authentication.
+* OPENCOST_PARQUET_AZURE_FEDERATED_TOKEN_FILE: Path to the federated token file for workload identity authentication. When omitted the exporter falls back to the `AZURE_FEDERATED_TOKEN_FILE` environment variable provided by Azure AD Workload Identity.
 * OPENCOST_PARQUET_AZURE_AUTH_MODE: Optional. Controls which Azure credential to use. Supported values are `auto` (default), `client-secret`, and `workload-identity`.
 
 ## GCP Specific Environment Variables

--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ The script supports the following environment variables:
 ## Azure Specific Environment Variables
 * OPENCOST_PARQUET_AZURE_STORAGE_ACCOUNT_NAME: Name of the Azure Storage Account you want to export the data to.
 * OPENCOST_PARQUET_AZURE_CONTAINER_NAME: The container within the storage account you want to save the data to. The service principal requires write permissions on the container.
-* OPENCOST_PARQUET_AZURE_TENANT: Your Azure Tenant ID.
-* OPENCOST_PARQUET_AZURE_APPLICATION_ID: Client ID of the Service Principal.
-* OPENCOST_PARQUET_AZURE_APPLICATION_SECRET: Secret of the Service Principal.
+* OPENCOST_PARQUET_AZURE_TENANT: Your Azure Tenant ID. When omitted the exporter falls back to the `AZURE_TENANT_ID` environment variable provided by Azure AD Workload Identity.
+* OPENCOST_PARQUET_AZURE_APPLICATION_ID: Client ID of the Service Principal. When omitted the exporter falls back to the `AZURE_CLIENT_ID` environment variable provided by Azure AD Workload Identity.
+* OPENCOST_PARQUET_AZURE_APPLICATION_SECRET: Secret of the Service Principal. Required when using client-secret authentication.
+* OPENCOST_PARQUET_AZURE_AUTH_MODE: Optional. Controls which Azure credential to use. Supported values are `auto` (default), `client-secret`, and `workload-identity`.
 
 ## GCP Specific Environment Variables
 * OPENCOST_PARQUET_GCP_BUCKET_NAME: Name of the GCP bucket you want to export the data to.
@@ -42,7 +43,12 @@ The script supports the following environment variables:
 ## AWS IAM
 
 ## Azure RBAC
-The current implementation allows for authentication via [Service Principals](https://learn.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals) on the Azure Storage Account. Therefore, to use the Azure storage backend, you need an existing service principal with the appropriate role assignments. Azure RBAC has built-in roles for Storage Account Blob Storage operations. The [Storage Blob Data Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-blob-data-contributor) allows writing data to an Azure Storage Account container. A less permissive custom role can be built and is encouraged!
+The exporter supports two authentication flows:
+
+1. **Client-secret (existing behaviour):** Provide `OPENCOST_PARQUET_AZURE_TENANT`, `OPENCOST_PARQUET_AZURE_APPLICATION_ID`, and `OPENCOST_PARQUET_AZURE_APPLICATION_SECRET`. This typically maps to a [Service Principal](https://learn.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals) with access to the storage account.
+2. **Azure AD Workload Identity / Managed Identity:** Set `OPENCOST_PARQUET_AZURE_AUTH_MODE=workload-identity` (or leave it as `auto` without specifying a secret) and rely on the Kubernetes workload identity webhook to inject `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_FEDERATED_TOKEN_FILE` from the annotated service account used. No client secret is required.
+
+Regardless of the chosen method, ensure the identity has write permissions on the storage account. The built-in [Storage Blob Data Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-blob-data-contributor) role is sufficient, though a more restricted custom role is recommended where possible.
 
 ## GCP IAM
 The current implementation allows for authentication using service account keys or Workload Identity. Ensure that the service account has the `Storage Object Creator` role or equivalent permissions to write data to the GCP bucket.

--- a/src/opencost_parquet_exporter.py
+++ b/src/opencost_parquet_exporter.py
@@ -146,6 +146,7 @@ def get_config(
             'azure_tenant': os.environ.get('OPENCOST_PARQUET_AZURE_TENANT') or os.environ.get('AZURE_TENANT_ID'),
             'azure_application_id': os.environ.get('OPENCOST_PARQUET_AZURE_APPLICATION_ID') or os.environ.get('AZURE_CLIENT_ID'),
             'azure_application_secret': os.environ.get('OPENCOST_PARQUET_AZURE_APPLICATION_SECRET'),
+            'azure_federated_token_file': os.environ.get('OPENCOST_PARQUET_AZURE_FEDERATED_TOKEN_FILE') or os.environ.get('AZURE_FEDERATED_TOKEN_FILE'),
             'azure_auth_mode': azure_auth_mode if azure_auth_mode in (
                 'auto', 'client-secret', 'workload-identity'
             ) else 'auto',

--- a/src/opencost_parquet_exporter.py
+++ b/src/opencost_parquet_exporter.py
@@ -137,13 +137,18 @@ def get_config(
 
     # Azure-specific configuration
     if config['storage_backend'] == 'azure':
+        azure_auth_mode = os.environ.get(
+            'OPENCOST_PARQUET_AZURE_AUTH_MODE', 'auto').lower()
         config.update({
             # pylint: disable=C0301
             'azure_storage_account_name': os.environ.get('OPENCOST_PARQUET_AZURE_STORAGE_ACCOUNT_NAME'),
             'azure_container_name': os.environ.get('OPENCOST_PARQUET_AZURE_CONTAINER_NAME'),
-            'azure_tenant': os.environ.get('OPENCOST_PARQUET_AZURE_TENANT'),
-            'azure_application_id': os.environ.get('OPENCOST_PARQUET_AZURE_APPLICATION_ID'),
+            'azure_tenant': os.environ.get('OPENCOST_PARQUET_AZURE_TENANT') or os.environ.get('AZURE_TENANT_ID'),
+            'azure_application_id': os.environ.get('OPENCOST_PARQUET_AZURE_APPLICATION_ID') or os.environ.get('AZURE_CLIENT_ID'),
             'azure_application_secret': os.environ.get('OPENCOST_PARQUET_AZURE_APPLICATION_SECRET'),
+            'azure_auth_mode': azure_auth_mode if azure_auth_mode in (
+                'auto', 'client-secret', 'workload-identity'
+            ) else 'auto',
         })
     if config['storage_backend'] == 'gcp':
         config.update({

--- a/src/storage/azure_storage.py
+++ b/src/storage/azure_storage.py
@@ -1,15 +1,24 @@
 # pylint: disable=W0511
 
 """
-This module provides an implementation of the BaseStorage class for Azure Blob Storage 
-with authentication via client secret credentials.
+This module provides an implementation of the BaseStorage class for Azure Blob Storage.
+
+Authentication supports both traditional client-secret credentials and Azure Workload
+Identity / managed identity. Client secret remains the default for backwards
+compatibility, but the credential strategy can be controlled via configuration.
 """
 
 from io import BytesIO
 import logging
+import os
 import sys
 import pandas as pd
-from azure.identity import ClientSecretCredential
+from azure.identity import (  # type: ignore[import]
+    ClientSecretCredential,
+    CredentialUnavailableError,
+    DefaultAzureCredential,
+    WorkloadIdentityCredential,
+)
 from azure.storage.blob import BlobServiceClient, BlobType
 from .base_storage import BaseStorage
 
@@ -26,6 +35,72 @@ class AzureStorage(BaseStorage):
 
     """
 
+    def _build_credentials(self, config):
+        """
+        Build the Azure credential object based on configuration/environment.
+
+        Priority:
+        1. Explicit client secret (default behaviour / backwards compatible)
+        2. Workload identity credential (either when requested or when no secret provided)
+        3. DefaultAzureCredential fallback (covers managed identity, CLI, etc.)
+        """
+        auth_mode = (config.get('azure_auth_mode') or 'auto').lower()
+        client_id = config.get('azure_application_id') or os.environ.get('AZURE_CLIENT_ID')
+        tenant_id = config.get('azure_tenant') or os.environ.get('AZURE_TENANT_ID')
+        secret = config.get('azure_application_secret')
+        token_file = os.environ.get('AZURE_FEDERATED_TOKEN_FILE')
+
+        def build_client_secret_credential():
+            missing = [name for name in (
+                'azure_tenant',
+                'azure_application_id',
+                'azure_application_secret',
+            ) if not config.get(name)]
+            if missing:
+                raise ValueError(
+                    f"Missing Azure client secret configuration values: {', '.join(missing)}")
+            return ClientSecretCredential(
+                config['azure_tenant'],
+                config['azure_application_id'],
+                config['azure_application_secret']
+            )
+
+        def build_workload_identity_credential():
+            if not client_id or not tenant_id or not token_file:
+                missing_env = [
+                    name for name, value in (
+                        ('AZURE_CLIENT_ID', client_id),
+                        ('AZURE_TENANT_ID', tenant_id),
+                        ('AZURE_FEDERATED_TOKEN_FILE', token_file),
+                    ) if not value
+                ]
+                raise CredentialUnavailableError(
+                    f"Workload identity environment variables missing: {', '.join(missing_env)}")
+            return WorkloadIdentityCredential(
+                client_id=client_id,
+                tenant_id=tenant_id,
+                token_file_path=token_file,
+            )
+
+        # Explicit client-secret mode or auto-detect with secret present
+        if auth_mode == 'client-secret' or (auth_mode == 'auto' and secret):
+            return build_client_secret_credential()
+
+        # Explicit workload-identity mode or auto-detect without secret
+        if auth_mode in ('workload-identity', 'auto'):
+            try:
+                return build_workload_identity_credential()
+            except CredentialUnavailableError as err:
+                logger.info("Workload identity credential unavailable: %s", err)
+                if auth_mode == 'workload-identity':
+                    raise
+
+        # Final fallback allows other DefaultAzureCredential sources (managed identity, CLI, etc.)
+        logger.info("Falling back to DefaultAzureCredential for Azure authentication")
+        return DefaultAzureCredential(
+            exclude_interactive_browser_credential=True
+        )
+
     def save_data(self, data: pd.core.frame.DataFrame, config) -> str | None:
         """
         Saves a DataFrame to Azure Blob Storage.
@@ -41,11 +116,23 @@ class AzureStorage(BaseStorage):
             str | None: The URL of the saved blob if successful, None otherwise.
 
         """
-        credentials = ClientSecretCredential(
-            config['azure_tenant'],
-            config['azure_application_id'],
-            config['azure_application_secret']
-        )
+        try:
+            credentials = self._build_credentials(config)
+        except (ValueError, CredentialUnavailableError) as err:
+            logger.error("Failed to build Azure credential: %s", err)
+            return None
+
+        missing_required = [
+            field for field in ('azure_storage_account_name', 'azure_container_name')
+            if not config.get(field)
+        ]
+        if missing_required:
+            logger.error(
+                "Missing required Azure storage configuration values: %s",
+                ', '.join(missing_required)
+            )
+            return None
+
         blob_service_client = BlobServiceClient(
             f"https://{config['azure_storage_account_name']}.blob.core.windows.net",
             logging_enable=True,

--- a/src/storage/azure_storage.py
+++ b/src/storage/azure_storage.py
@@ -48,7 +48,7 @@ class AzureStorage(BaseStorage):
         client_id = config.get('azure_application_id') or os.environ.get('AZURE_CLIENT_ID')
         tenant_id = config.get('azure_tenant') or os.environ.get('AZURE_TENANT_ID')
         secret = config.get('azure_application_secret')
-        token_file = os.environ.get('AZURE_FEDERATED_TOKEN_FILE')
+        token_file = config.get('azure_federated_token_file') or os.environ.get('AZURE_FEDERATED_TOKEN_FILE')
 
         def build_client_secret_credential():
             missing = [name for name in (

--- a/src/test_opencost_parquet_exporter.py
+++ b/src/test_opencost_parquet_exporter.py
@@ -81,6 +81,7 @@ class TestGetConfig(unittest.TestCase):
                 'OPENCOST_PARQUET_AZURE_AUTH_MODE': 'workload-identity',
                 'AZURE_CLIENT_ID': 'identity-client-id',
                 'AZURE_TENANT_ID': 'identity-tenant-id',
+                'AZURE_FEDERATED_TOKEN_FILE': '/var/run/secrets/azure/tokens/token',
                 'OPENCOST_PARQUET_FILE_KEY_PREFIX': 'prefix/',
                 'OPENCOST_PARQUET_WINDOW_START': '2020-01-01T00:00:00Z',
                 'OPENCOST_PARQUET_WINDOW_END': '2020-01-01T23:59:59Z'}, clear=True):
@@ -91,6 +92,25 @@ class TestGetConfig(unittest.TestCase):
             self.assertEqual(config['azure_container_name'], 'testcontainer')
             self.assertEqual(config['azure_application_id'], 'identity-client-id')
             self.assertEqual(config['azure_tenant'], 'identity-tenant-id')
+            self.assertEqual(config['azure_federated_token_file'], '/var/run/secrets/azure/tokens/token')
+
+    def test_get_azure_config_with_opencost_token_file_precedence(self):
+        """Test OPENCOST_PARQUET_AZURE_FEDERATED_TOKEN_FILE takes precedence over AZURE_FEDERATED_TOKEN_FILE."""
+        with patch.dict(os.environ, {
+                'OPENCOST_PARQUET_STORAGE_BACKEND': 'azure',
+                'OPENCOST_PARQUET_AZURE_STORAGE_ACCOUNT_NAME': 'testaccount',
+                'OPENCOST_PARQUET_AZURE_CONTAINER_NAME': 'testcontainer',
+                'OPENCOST_PARQUET_AZURE_AUTH_MODE': 'workload-identity',
+                'AZURE_CLIENT_ID': 'identity-client-id',
+                'AZURE_TENANT_ID': 'identity-tenant-id',
+                'OPENCOST_PARQUET_AZURE_FEDERATED_TOKEN_FILE': '/custom/token/path',
+                'AZURE_FEDERATED_TOKEN_FILE': '/var/run/secrets/azure/tokens/token',
+                'OPENCOST_PARQUET_FILE_KEY_PREFIX': 'prefix/',
+                'OPENCOST_PARQUET_WINDOW_START': '2020-01-01T00:00:00Z',
+                'OPENCOST_PARQUET_WINDOW_END': '2020-01-01T23:59:59Z'}, clear=True):
+            config = get_config()
+
+            self.assertEqual(config['azure_federated_token_file'], '/custom/token/path')
 
     def test_get_gcp_config_with_env_vars(self):
         """Test get_config returns correct configurations based on environment variables."""
@@ -336,6 +356,7 @@ class TestAzureStorageCredentialSelection(unittest.TestCase):
             'azure_application_secret': None,
             'azure_tenant': None,
             'azure_application_id': None,
+            'azure_federated_token_file': None,
         }
         with patch.dict(os.environ, {
                 'AZURE_CLIENT_ID': 'workload-client-id',
@@ -347,6 +368,26 @@ class TestAzureStorageCredentialSelection(unittest.TestCase):
             client_id='workload-client-id',
             tenant_id='workload-tenant',
             token_file_path='/tmp/token'
+        )
+        self.assertEqual(credential, mock_workload.return_value)
+
+    @patch('storage.azure_storage.WorkloadIdentityCredential')
+    def test_workload_identity_mode_uses_config_values(self, mock_workload):
+        """Ensure workload identity credential is built from config dict."""
+        config = {
+            'azure_auth_mode': 'workload-identity',
+            'azure_application_secret': None,
+            'azure_tenant': 'config-tenant',
+            'azure_application_id': 'config-client-id',
+            'azure_federated_token_file': '/config/token',
+        }
+        with patch.dict(os.environ, {}, clear=True):
+            credential = self.azure_storage._build_credentials(config)
+
+        mock_workload.assert_called_once_with(
+            client_id='config-client-id',
+            tenant_id='config-tenant',
+            token_file_path='/config/token'
         )
         self.assertEqual(credential, mock_workload.return_value)
 

--- a/src/test_opencost_parquet_exporter.py
+++ b/src/test_opencost_parquet_exporter.py
@@ -4,8 +4,10 @@ from unittest.mock import patch, MagicMock, mock_open
 import json
 import os
 import requests
+from azure.identity import CredentialUnavailableError
 from freezegun import freeze_time
 from opencost_parquet_exporter import get_config, request_data, load_config_file
+from storage.azure_storage import AzureStorage
 
 
 class TestGetConfig(unittest.TestCase):
@@ -66,8 +68,29 @@ class TestGetConfig(unittest.TestCase):
             self.assertEqual(config['azure_tenant'], 'testtenant')
             self.assertEqual(config['azure_application_id'], 'testid')
             self.assertEqual(config['azure_application_secret'], 'testsecret')
+            self.assertEqual(config['azure_auth_mode'], 'auto')
             self.assertEqual(config['params'][1][1], 'true')
             self.assertEqual(config['params'][2][1], 'true')
+
+    def test_get_azure_config_workload_identity_mode(self):
+        """Test get_config populates workload identity defaults when requested."""
+        with patch.dict(os.environ, {
+                'OPENCOST_PARQUET_STORAGE_BACKEND': 'azure',
+                'OPENCOST_PARQUET_AZURE_STORAGE_ACCOUNT_NAME': 'testaccount',
+                'OPENCOST_PARQUET_AZURE_CONTAINER_NAME': 'testcontainer',
+                'OPENCOST_PARQUET_AZURE_AUTH_MODE': 'workload-identity',
+                'AZURE_CLIENT_ID': 'identity-client-id',
+                'AZURE_TENANT_ID': 'identity-tenant-id',
+                'OPENCOST_PARQUET_FILE_KEY_PREFIX': 'prefix/',
+                'OPENCOST_PARQUET_WINDOW_START': '2020-01-01T00:00:00Z',
+                'OPENCOST_PARQUET_WINDOW_END': '2020-01-01T23:59:59Z'}, clear=True):
+            config = get_config()
+
+            self.assertEqual(config['azure_auth_mode'], 'workload-identity')
+            self.assertEqual(config['azure_storage_account_name'], 'testaccount')
+            self.assertEqual(config['azure_container_name'], 'testcontainer')
+            self.assertEqual(config['azure_application_id'], 'identity-client-id')
+            self.assertEqual(config['azure_tenant'], 'identity-tenant-id')
 
     def test_get_gcp_config_with_env_vars(self):
         """Test get_config returns correct configurations based on environment variables."""
@@ -280,6 +303,82 @@ class TestLoadConfigMaps(unittest.TestCase):
         """ Test the function's response to an empty JSON file """
         with self.assertRaises(json.JSONDecodeError):
             load_config_file(self.empty_json_path)
+
+
+class TestAzureStorageCredentialSelection(unittest.TestCase):
+    """Test credential selection logic for Azure storage backend."""
+
+    def setUp(self):
+        self.azure_storage = AzureStorage()
+
+    @patch('storage.azure_storage.WorkloadIdentityCredential')
+    @patch('storage.azure_storage.ClientSecretCredential')
+    def test_auto_prefers_client_secret_when_secret_present(
+            self, mock_client_secret, mock_workload):
+        """Ensure client secret path is used when credentials provided."""
+        config = {
+            'azure_auth_mode': 'auto',
+            'azure_tenant': 'tenant',
+            'azure_application_id': 'app-id',
+            'azure_application_secret': 'secret',
+        }
+        credential = self.azure_storage._build_credentials(config)
+
+        mock_client_secret.assert_called_once_with('tenant', 'app-id', 'secret')
+        mock_workload.assert_not_called()
+        self.assertEqual(credential, mock_client_secret.return_value)
+
+    @patch('storage.azure_storage.WorkloadIdentityCredential')
+    def test_workload_identity_mode_uses_env_values(self, mock_workload):
+        """Ensure workload identity credential is built from environment."""
+        config = {
+            'azure_auth_mode': 'workload-identity',
+            'azure_application_secret': None,
+            'azure_tenant': None,
+            'azure_application_id': None,
+        }
+        with patch.dict(os.environ, {
+                'AZURE_CLIENT_ID': 'workload-client-id',
+                'AZURE_TENANT_ID': 'workload-tenant',
+                'AZURE_FEDERATED_TOKEN_FILE': '/tmp/token'}, clear=True):
+            credential = self.azure_storage._build_credentials(config)
+
+        mock_workload.assert_called_once_with(
+            client_id='workload-client-id',
+            tenant_id='workload-tenant',
+            token_file_path='/tmp/token'
+        )
+        self.assertEqual(credential, mock_workload.return_value)
+
+    @patch('storage.azure_storage.DefaultAzureCredential')
+    @patch('storage.azure_storage.WorkloadIdentityCredential')
+    def test_auto_falls_back_to_default_when_workload_unavailable(
+            self, mock_workload, mock_default):
+        """Ensure auto mode falls back when workload identity env is missing."""
+        config = {
+            'azure_auth_mode': 'auto',
+            'azure_application_secret': None,
+            'azure_tenant': None,
+            'azure_application_id': None,
+        }
+        with patch.dict(os.environ, {}, clear=True):
+            credential = self.azure_storage._build_credentials(config)
+
+        mock_workload.assert_not_called()
+        mock_default.assert_called_once_with(
+            exclude_interactive_browser_credential=True)
+        self.assertEqual(credential, mock_default.return_value)
+
+    def test_client_secret_mode_missing_values_raises(self):
+        """Ensure missing client-secret config raises an error."""
+        config = {
+            'azure_auth_mode': 'client-secret',
+            'azure_application_secret': None,
+            'azure_tenant': None,
+            'azure_application_id': None,
+        }
+        with self.assertRaises(ValueError):
+            self.azure_storage._build_credentials(config)
 
 
 if __name__ == '__main__':

--- a/src/test_opencost_parquet_exporter.py
+++ b/src/test_opencost_parquet_exporter.py
@@ -81,7 +81,7 @@ class TestGetConfig(unittest.TestCase):
                 'OPENCOST_PARQUET_AZURE_AUTH_MODE': 'workload-identity',
                 'AZURE_CLIENT_ID': 'identity-client-id',
                 'AZURE_TENANT_ID': 'identity-tenant-id',
-                'AZURE_FEDERATED_TOKEN_FILE': '/var/run/secrets/azure/tokens/token',
+                'AZURE_FEDERATED_TOKEN_FILE': '/var/run/secrets/azure/tokens/azure-identity-token',
                 'OPENCOST_PARQUET_FILE_KEY_PREFIX': 'prefix/',
                 'OPENCOST_PARQUET_WINDOW_START': '2020-01-01T00:00:00Z',
                 'OPENCOST_PARQUET_WINDOW_END': '2020-01-01T23:59:59Z'}, clear=True):
@@ -92,7 +92,7 @@ class TestGetConfig(unittest.TestCase):
             self.assertEqual(config['azure_container_name'], 'testcontainer')
             self.assertEqual(config['azure_application_id'], 'identity-client-id')
             self.assertEqual(config['azure_tenant'], 'identity-tenant-id')
-            self.assertEqual(config['azure_federated_token_file'], '/var/run/secrets/azure/tokens/token')
+            self.assertEqual(config['azure_federated_token_file'], '/var/run/secrets/azure/tokens/azure-identity-token')
 
     def test_get_azure_config_with_opencost_token_file_precedence(self):
         """Test OPENCOST_PARQUET_AZURE_FEDERATED_TOKEN_FILE takes precedence over AZURE_FEDERATED_TOKEN_FILE."""
@@ -104,7 +104,7 @@ class TestGetConfig(unittest.TestCase):
                 'AZURE_CLIENT_ID': 'identity-client-id',
                 'AZURE_TENANT_ID': 'identity-tenant-id',
                 'OPENCOST_PARQUET_AZURE_FEDERATED_TOKEN_FILE': '/custom/token/path',
-                'AZURE_FEDERATED_TOKEN_FILE': '/var/run/secrets/azure/tokens/token',
+                'AZURE_FEDERATED_TOKEN_FILE': '/var/run/secrets/azure/tokens/azure-identity-token',
                 'OPENCOST_PARQUET_FILE_KEY_PREFIX': 'prefix/',
                 'OPENCOST_PARQUET_WINDOW_START': '2020-01-01T00:00:00Z',
                 'OPENCOST_PARQUET_WINDOW_END': '2020-01-01T23:59:59Z'}, clear=True):


### PR DESCRIPTION
Hello There 👋  

I'm in need to deploy the exporter, but don't want to rely on azure service principals, much less secret management for it.
Decided to quickly support workload identity in the exporter for federated service accounts in the cronjobs.

Azure Workload Identity support for Azure Storage Blob.
Resolving Issue #30